### PR TITLE
Update devcontainer to install github cli, launch browser, run hugo serve

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,8 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": {},
 
+	"features": {"github-cli": "latest"},
+
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"akmittal.hugofy",
@@ -49,4 +51,15 @@
 	"remoteUser": "vscode",
 
 	"workspaceMount": "source=${localWorkspaceFolder}/,target=${containerWorkspaceFolder},type=bind,consistency=delegated",
+
+	// Run hugo serve on startup of devcontainer
+	"postStartCommand": "hugo serve",
+
+	// Launch GitBOM Website in browser
+	"portsAttributes": {
+		"1313": {
+			"label": "GitBOM Website",
+			"onAutoForward": "openBrowser"
+		}
+	},
 }


### PR DESCRIPTION
By default now runs "hugo serve" and auto launches a browser
in the host to display the live update of the page as you edit it.

Adds the github cli to dev container.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
