### PR TITLE
Fix minor typo

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -3,7 +3,7 @@ title: OmniBOR
 ---
 {{< home/section title="What?" iconclass="fas fa-2x fa-power-off">}}
 
-**[OmniBOR](/glossary/omnibor)** Universal **B**ill **O**f **R**eceipts) is a minimalistic scheme for [build tools](/glossary/build_tool) to:
+**[OmniBOR](/glossary/omnibor)** (Universal **B**ill **O**f **R**eceipts) is a minimalistic scheme for [build tools](/glossary/build_tool) to:
 1. Build a compact [Artifact Dependency Graph (ADG)](/glossary/artifact_dependency_graph), tracking every source code file incorporated into each built [artifact](/glossary/artifact).
 2. Embed a unique, content-addressable reference for that [Artifact Dependency Graph (ADG)](/glossary/artifact_dependency_graph/), the [OmniBOR identifier](/glossary/omnibor/#omnibor-identifier), into the [artifact](/glossary/artifact) at build time.
 


### PR DESCRIPTION
- Minimum shift for renaming to omnibor
- Make acronym-expansion first on the landing page
- Fix minor typo
