### PR TITLE
Update base docker image version in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 			// Update the GO_VERSION arg to pick a version of Go: 1, 1.16, 1.17
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local arm64/Apple Silicon.
-			"GO_VERSION": "1.17-bullseye",
+			"GO_VERSION": "1.19-bullseye",
 			// Options
 			"NODE_VERSION": "14"
 		}


### PR DESCRIPTION
The older base docker image contained expired keys causing
the entire 'devcontainer' build to fail.  This fixes that.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
